### PR TITLE
fix: add README.md to files in package config

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -18,7 +18,7 @@
       "require": "./dist/plugin/index.cjs"
     }
   },
-  "files": ["dist", "plugin", "static"],
+  "files": ["dist", "plugin", "static", "README.md"],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
### Summary

add `README.md` to files so it's included with the published package

### Test plan

n/a
