### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .rslib
+doc_build


### PR DESCRIPTION
### Summary

updated gitignore to ignore tester build dir (`doc_build`)

### Test plan

n/a
