### PR TITLE
fix: use withBase from runtime

### DIFF
--- a/packages/theme/src/theme/components/home-hero/index.tsx
+++ b/packages/theme/src/theme/components/home-hero/index.tsx
@@ -1,6 +1,6 @@
 import type { FrontMatterMeta } from '@rspress/shared';
-import { normalizeHrefInRuntime, normalizeImagePath } from '@runtime';
-import { isExternalUrl, withBase } from '@shared';
+import { normalizeHrefInRuntime, normalizeImagePath, withBase } from '@runtime';
+import { isExternalUrl } from '@shared';
 import { Button } from 'src/theme/primitives';
 import styles from './index.module.scss';
 


### PR DESCRIPTION
### Summary

- [x] - to include base path in the URL we should be using `withBase` from runtime and not shared utils

### Test plan

n/a
