### PR TITLE
fix: landing unclickable elements

### DIFF
--- a/packages/theme/src/styles/styles.css
+++ b/packages/theme/src/styles/styles.css
@@ -704,6 +704,7 @@ div#root > section > div.rp-relative::before {
   content: "";
   position: absolute;
   inset: 0;
+  z-index: -100;
   background-image: url("../assets/hero-bg-shape.svg"), var(--ck-bg-radial-1);
   background-repeat: no-repeat, no-repeat;
   background-size: contain, contain;
@@ -721,6 +722,7 @@ div#root > section > div.rp-relative::after {
   content: "";
   position: absolute;
   inset: 0;
+  z-index: -100;
   background-image: url("../assets/noise.svg");
   background-repeat: repeat;
   background-size: cover;
@@ -756,6 +758,7 @@ div#root > section:not(:has(div[class^="docLayout_"]))::before {
   bottom: 0;
   top: auto;
   height: 100%;
+  z-index: -100;
   pointer-events: none;
   background-image: url("../assets/noise.svg");
   background-repeat: repeat;


### PR DESCRIPTION
### Summary

- [x] - fixed an issue on landing page where elements are unclickable after https://github.com/callstack/rspress-theme/pull/25

### Test plan

- [x] - elements are clickable in tester