### PR TITLE
fix: remove fixed height style for HomeHero container

### DIFF
--- a/packages/theme/src/theme/components/home-hero/index.module.scss
+++ b/packages/theme/src/theme/components/home-hero/index.module.scss
@@ -94,6 +94,17 @@
   }
 }
 
+.container {
+  padding-top: 1.6rem;
+}
+
+@media (min-width: 960px) {
+  .container {
+    padding-top: 155px;
+    padding-bottom: 155px;
+  }
+}
+
 @media (max-width: 640px) {
   .heroMain {
     display: flex;
@@ -116,10 +127,6 @@
   .heroActions {
     justify-content: center;
   }
-}
-
-.container {
-  padding-top: 1.6rem;
 }
 
 @media (max-width: 400px) {

--- a/packages/theme/src/theme/components/home-hero/index.module.scss
+++ b/packages/theme/src/theme/components/home-hero/index.module.scss
@@ -118,11 +118,11 @@
   }
 }
 
-@media (max-width: 400px) {
-  .container {
-    height: 65vh;
-  }
+.container {
+  padding-top: 1.6rem;
+}
 
+@media (max-width: 400px) {
   .heroTaglineActions {
     align-self: center;
     margin-bottom: 0;

--- a/packages/theme/src/theme/components/home-hero/index.module.scss
+++ b/packages/theme/src/theme/components/home-hero/index.module.scss
@@ -1,7 +1,6 @@
 .container {
   margin: 0 auto;
   width: calc(100% - 8 * 2px);
-  height: 50vh;
   max-height: 600px;
   display: flex;
   flex-direction: column;

--- a/packages/theme/src/theme/components/home-hero/index.module.scss
+++ b/packages/theme/src/theme/components/home-hero/index.module.scss
@@ -8,6 +8,8 @@
   align-items: flex-start;
   position: relative;
   overflow: hidden;
+  padding-top: 155px;
+  padding-bottom: 155px;
 }
 
 .heroMain {
@@ -62,6 +64,11 @@
 }
 
 @media (max-width: 960px) {
+  .container {
+    padding-top: 1.6rem;
+    padding-bottom: 1.6rem;
+  }
+
   .heroMain {
     flex-direction: row;
     align-items: center;
@@ -91,17 +98,6 @@
 
   .heroActions {
     align-self: center;
-  }
-}
-
-.container {
-  padding-top: 1.6rem;
-}
-
-@media (min-width: 960px) {
-  .container {
-    padding-top: 155px;
-    padding-bottom: 155px;
   }
 }
 


### PR DESCRIPTION
### Summary

This PR fixes a style problem with the `HomeHero` component container's style, which enforced a fixed height of `50vh`. This - for larger heroes - may have produced an overflow, which would be clipped. The effect before & after this fix is as follows (screenshots in the table are before other fixes for paddings were applied, just to picture the overflow):
| Before | After |
| --- | --- |
| <img width="865" height="281" alt="image" src="https://github.com/user-attachments/assets/9738265b-7167-48b6-97b4-58c2bd232a6f" /> | <img width="865" height="281" alt="image" src="https://github.com/user-attachments/assets/cbcb47a8-82eb-4189-aff4-6fb502b74611" /> |

### Test plan

- run the tester app with custom contents
- test on different screen sizes:

#### Large logo

<img width="350" alt="largelogo-desktop" src="https://github.com/user-attachments/assets/06f70a01-1723-4dfc-bdfc-8f672144ef40" />
<img width="250" alt="largelogo-se" src="https://github.com/user-attachments/assets/44911bdf-1d8b-48d4-bcd8-ac1e64f1cdda" />
<img width="250" alt="largelogo-xr" src="https://github.com/user-attachments/assets/b6ec4a9f-9f5e-4f0b-b4ba-a49b4cc2602a" />

#### "Long" hero contents

<img width="350" alt="long-desktop" src="https://github.com/user-attachments/assets/aa8b772b-eade-4d10-9ee1-07d9787f9b89" />
<img width="250" alt="long-se" src="https://github.com/user-attachments/assets/778b437e-3264-4296-b466-27bc04bb5a7e" />
<img width="250" alt="long-xr" src="https://github.com/user-attachments/assets/8c93b58f-7833-4223-8700-d6e2dd5a76ca" />

#### "Short" hero contents

<img width="350" alt="short-desktop" src="https://github.com/user-attachments/assets/9b983200-c6b7-437c-a8f7-5d68a118b881" />
<img width="250" alt="short-se" src="https://github.com/user-attachments/assets/4d88b73c-19c1-42cf-b8f7-bb61c7f09260" />
<img width="250" alt="short-xr" src="https://github.com/user-attachments/assets/e4a7874a-d041-4993-a527-ca409fa971d6" />
