### PR TITLE
docs: update template of theme entrypoint to re-export LinkCard and other customized components

### DIFF
--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -92,6 +92,7 @@ import {
   LinkCard,
   OutlineCTA,
   PrevNextPage,
+  VersionBadge,
 } from '@callstack/rspress-theme';
 import {
   HomeLayout as RspressHomeLayout,
@@ -132,6 +133,8 @@ export {
   HomeFeature,
   HomeHero,
   LinkCard,
+  VersionBadge,
+  Announcement,
 };
 // Don't forget to export the default theme components which are not overridden
 export * from 'rspress/theme';


### PR DESCRIPTION
### Summary

This PR modifies the template of `theme/index.ts` in `README.md` to re-export customized components from there such as `LinkCard`. This is important to easily expose a consistent, customized style, especially as the rspress-exported `LinkCard` is currently broken on rspress `beta.19` and `beta.20`.

### Test plan

integrated this way in https://github.com/callstackincubator/react-native-legal/commit/86660d7d3ba356e1f645e0d51a93dcf2e2d0c1cb
