### PR TITLE
feat: turn on button hover animation only on fine pointers (not touch devices)

### DIFF
--- a/packages/theme/src/theme/components/button/index.module.scss
+++ b/packages/theme/src/theme/components/button/index.module.scss
@@ -15,14 +15,16 @@
     color 0.45s cubic-bezier(0.625, 0.05, 0, 1),
     transform 0.45s cubic-bezier(0.625, 0.05, 0, 1);
 
-  &:hover {
-    color: #ffffff;
-    background-position: left bottom;
-  }
+  @media (pointer: fine) {
+    &:hover {
+      color: #ffffff;
+      background-position: left bottom;
+    }
 
-  &:hover svg.button-icon > path {
-    animation: slide-out 0.2s cubic-bezier(0.625, 0.05, 0, 1),
-      slide-in 0.25s cubic-bezier(0.625, 0.05, 0, 1) 0.2s;
+    &:hover svg.button-icon > path {
+      animation: slide-out 0.2s cubic-bezier(0.625, 0.05, 0, 1),
+        slide-in 0.25s cubic-bezier(0.625, 0.05, 0, 1) 0.2s;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Essentially turn off button hover animation for touch devices, as it feels weird.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
