### PR TITLE
fix: hero spacing and constrained height

### DIFF
--- a/packages/theme/src/theme/components/home-hero/index.module.scss
+++ b/packages/theme/src/theme/components/home-hero/index.module.scss
@@ -1,15 +1,14 @@
 .container {
   margin: 0 auto;
   width: calc(100% - 8 * 2px);
-  max-height: 600px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
   position: relative;
   overflow: hidden;
-  padding-top: 155px;
-  padding-bottom: 155px;
+  padding-top: 12vh;
+  padding-bottom: 6vh;
 }
 
 .heroMain {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Increase the margin between hero section and header (to give visual space between repeated logo) and removed the arbitrary height, which would crop some longer descriptions. 
<img width="1512" height="793" alt="image" src="https://github.com/user-attachments/assets/a533d561-b79d-4ff7-816d-287d4b42527f" />


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
