### PR TITLE
chore: split workflows, make them secure

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -3,10 +3,11 @@
 name: Lint PR Title
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
+      - synchronize
 
 jobs:
   lint-pr-title:

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -1,10 +1,11 @@
 name: PR Labeler
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
+      - synchronize
 
 jobs:
   release-labeling:


### PR DESCRIPTION
### Summary

- [x] - splits the workflows into `lint-pr` & `pr-labeler`
- [x] - make sure these jobs are only run in our repository
- [x] - permissions are scoped to jobs
- [x] - 3rd party actions are pinned to commits 

### Test plan

n/a
