### PR TITLE
fix: drop build time aliases in favour of `rspress` imports

### DIFF
--- a/packages/tester/package.json
+++ b/packages/tester/package.json
@@ -11,7 +11,7 @@
     "preview": "rspress preview"
   },
   "dependencies": {
-    "rspress": "^2.0.0-beta.18",
+    "rspress": "^2.0.0-beta.21",
     "@callstack/rspress-theme": "workspace:*"
   },
   "devDependencies": {

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -45,7 +45,7 @@ The theme uses **Alliance No. 2** as the header font family. This is a licensed 
 3. **Link the styles in your Rspress config** by adding the `globalStyles` option:
 
 ```ts
-import { defineConfig } from '@rspress/shared';
+import { defineConfig } from 'rspress/core';
 import { pluginCallstackTheme } from '@callstack/rspress-theme/plugin';
 
 export default defineConfig({
@@ -63,7 +63,7 @@ To use the `rspress-theme` package, you need to add the plugin to the Rspress co
 In your `rspress.config.ts` file, import `pluginCallstackTheme` from `@callstack/rspress-theme/plugin` and add it to the plugins array:
 
 ```ts
-import { defineConfig } from '@rspress/shared';
+import { defineConfig } from 'rspress/core';
 import { pluginCallstackTheme } from '@callstack/rspress-theme/plugin';
 
 export default defineConfig({

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -46,7 +46,8 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "react": "^19.0.0"
+    "react": "^19.0.0",
+    "rspress": "^2.0.0-beta.21"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.52.8",
@@ -55,10 +56,10 @@
     "@rsbuild/plugin-sass": "^1.3.3",
     "@rsbuild/plugin-svgr": "^1.2.1",
     "@rslib/core": "^0.10.5",
-    "@rspress/shared": "^2.0.0-beta.18",
     "@types/node": "^22",
     "@types/react": "^19",
     "react": "^19",
+    "rspress": "^2.0.0-beta.21",
     "typescript": "^5.8.3"
   }
 }

--- a/packages/theme/rslib.config.ts
+++ b/packages/theme/rslib.config.ts
@@ -27,7 +27,7 @@ const themeConfig: LibConfig = {
   },
   output: {
     distPath: { root: './dist' },
-    externals: ['@runtime', '@theme', '@shared'],
+    externals: ['@theme'],
     target: 'web',
   },
   plugins: [pluginImageCompress(), pluginReact(), pluginSass(), pluginSvgr()],

--- a/packages/theme/src/plugin/index.ts
+++ b/packages/theme/src/plugin/index.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { RspressPlugin, UserConfig } from '@rspress/shared';
+import type { RspressPlugin, UserConfig } from 'rspress/core';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -49,14 +49,5 @@ export function pluginCallstackTheme(): RspressPlugin {
     },
     // inject style overrides
     globalStyles: path.join(path.dirname(dirname), 'styles/styles.css'),
-    // add aliases for runtime and shared
-    builderConfig: {
-      resolve: {
-        alias: {
-          '@runtime': '@rspress/core/runtime',
-          '@shared': '@rspress/shared',
-        },
-      },
-    },
   };
 }

--- a/packages/theme/src/theme/components/announcement/index.tsx
+++ b/packages/theme/src/theme/components/announcement/index.tsx
@@ -1,5 +1,5 @@
-import { NoSSR } from '@runtime';
 import { useState } from 'react';
+import { NoSSR } from 'rspress/runtime';
 import IconClose from './close.svg?react';
 import styles from './index.module.scss';
 

--- a/packages/theme/src/theme/components/button/index.ts
+++ b/packages/theme/src/theme/components/button/index.ts
@@ -1,6 +1,6 @@
-import { useDark } from '@runtime';
 import { Link } from '@theme';
 import * as React from 'react';
+import { useDark } from 'rspress/runtime';
 import IconArrowBarRight from './arrow-bar-right.svg?react';
 import IconCorner from './corner-down-right.svg?react';
 import styles from './index.module.scss';

--- a/packages/theme/src/theme/components/home-feature/index.tsx
+++ b/packages/theme/src/theme/components/home-feature/index.tsx
@@ -1,6 +1,9 @@
-import type { Feature, FrontMatterMeta } from '@rspress/shared';
-import { normalizeHrefInRuntime, withBase } from '@runtime';
-import { isExternalUrl } from '@shared';
+import {
+  isExternalUrl,
+  normalizeHrefInRuntime,
+  withBase,
+} from 'rspress/runtime';
+import type { Feature, FrontMatterMeta } from '../../types';
 import { renderHtmlOrText } from '../../utils';
 import styles from './index.module.scss';
 

--- a/packages/theme/src/theme/components/home-footer/index.tsx
+++ b/packages/theme/src/theme/components/home-footer/index.tsx
@@ -1,5 +1,5 @@
-import { usePageData } from '@runtime';
 import { Link, SocialLinks } from '@theme';
+import { usePageData } from 'rspress/runtime';
 import CKLogoDark from './ck-logo-dark.svg?react';
 import CKLogoLight from './ck-logo-light.svg?react';
 import styles from './index.module.scss';

--- a/packages/theme/src/theme/components/home-hero/index.tsx
+++ b/packages/theme/src/theme/components/home-hero/index.tsx
@@ -1,6 +1,10 @@
-import type { FrontMatterMeta } from '@rspress/shared';
-import { normalizeHrefInRuntime, normalizeImagePath, withBase } from '@runtime';
-import { isExternalUrl } from '@shared';
+import {
+  isExternalUrl,
+  normalizeHrefInRuntime,
+  normalizeImagePath,
+  withBase,
+} from 'rspress/runtime';
+import type { FrontMatterMeta, Hero } from '../../types';
 import { renderHtmlOrText } from '../../utils';
 import { Button } from '../button';
 import styles from './index.module.scss';
@@ -11,7 +15,7 @@ const DEFAULT_HERO = {
   tagline: '',
   actions: [],
   image: undefined,
-} satisfies FrontMatterMeta['hero'];
+} satisfies Hero;
 
 interface HomeHeroProps {
   frontmatter: FrontMatterMeta;
@@ -24,7 +28,6 @@ function HomeHero({
   beforeHeroActions,
   afterHeroActions,
   frontmatter,
-  routePath,
 }: HomeHeroProps) {
   const hero = frontmatter.hero ?? DEFAULT_HERO;
   const imageSrc =
@@ -67,7 +70,7 @@ function HomeHero({
           {hero.actions.map((action) => {
             const link = isExternalUrl(action.link)
               ? action.link
-              : normalizeHrefInRuntime(withBase(action.link, routePath));
+              : normalizeHrefInRuntime(withBase(action.link));
 
             return (
               <Button

--- a/packages/theme/src/theme/components/version-badge/index.tsx
+++ b/packages/theme/src/theme/components/version-badge/index.tsx
@@ -1,5 +1,5 @@
-import { usePageData } from '@runtime';
 import { Badge } from '@theme';
+import { usePageData } from 'rspress/runtime';
 
 interface VersionBadgeProps {
   version?: string;

--- a/packages/theme/src/theme/global.d.ts
+++ b/packages/theme/src/theme/global.d.ts
@@ -23,5 +23,3 @@ declare module '*.avif' {
 
 // rspress aliases
 declare module '@theme';
-declare module '@runtime';
-declare module '@shared';

--- a/packages/theme/src/theme/types.ts
+++ b/packages/theme/src/theme/types.ts
@@ -1,0 +1,48 @@
+export interface Hero {
+  name: string;
+  text: string;
+  tagline: string;
+  image?: {
+    src: string | { dark: string; light: string };
+    alt: string;
+    /**
+     * `srcset` and `sizes` are attributes of `<img>` tag. Please refer to https://mdn.io/srcset for the usage.
+     * When the value is an array, rspress will join array members with commas.
+     **/
+    sizes?: string | string[];
+    srcset?: string | string[];
+  };
+  actions: {
+    text: string;
+    link: string;
+    theme: 'brand' | 'alt';
+  }[];
+}
+
+export interface Feature {
+  icon: string;
+  title: string;
+  details: string;
+  span?: number;
+  link?: string;
+}
+
+export type PageType = 'home' | 'doc' | 'custom' | '404' | 'blank';
+
+export interface FrontMatterMeta {
+  title?: string;
+  description?: string;
+  overview?: boolean;
+  pageType?: PageType;
+  features?: Feature[];
+  hero?: Hero;
+  sidebar?: boolean;
+  outline?: boolean;
+  lineNumbers?: boolean;
+  overviewHeaders?: number[];
+  titleSuffix?: string;
+  head?: [string, Record<string, string>][];
+  context?: string;
+  footer?: boolean;
+  [key: string]: unknown;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: workspace:*
         version: link:../theme
       rspress:
-        specifier: ^2.0.0-beta.18
-        version: 2.0.0-beta.18(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.97.1)
+        specifier: ^2.0.0-beta.21
+        version: 2.0.0-beta.21(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.97.1)
     devDependencies:
       '@types/node':
         specifier: ^22
@@ -51,9 +51,6 @@ importers:
       '@rslib/core':
         specifier: ^0.10.5
         version: 0.10.5(@microsoft/api-extractor@7.52.8(@types/node@22.7.7))(typescript@5.8.3)
-      '@rspress/shared':
-        specifier: ^2.0.0-beta.18
-        version: 2.0.0-beta.18
       '@types/node':
         specifier: ^22
         version: 22.7.7
@@ -63,6 +60,9 @@ importers:
       react:
         specifier: ^19
         version: 19.1.0
+      rspress:
+        specifier: ^2.0.0-beta.21
+        version: 2.0.0-beta.21(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.97.1)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -513,6 +513,11 @@ packages:
     engines: {node: '>=16.10.0'}
     hasBin: true
 
+  '@rsbuild/core@1.4.6':
+    resolution: {integrity: sha512-Z5e7ExKGmLv/wvBQEgSE2bPpR9movvq0jnfXjtYzrLzJFGsKFwL/5KShgdr6hUtVGGLoCCCHHHaTBL6BPcNvZA==}
+    engines: {node: '>=16.10.0'}
+    hasBin: true
+
   '@rsbuild/plugin-image-compress@1.2.0':
     resolution: {integrity: sha512-FxbJ++qgGMLPTHZ6psOJeldp95ChOR/pO11rVSlCC45vB/RRh/AB+5vA1I3La9uxEqP91w4ED1UJ7dZ/Rj1fcQ==}
     peerDependencies:
@@ -554,8 +559,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@1.4.6':
+    resolution: {integrity: sha512-K37H8e58eY7zBHGeMVtT7m0Z5XvlNQX7YDuaxlbiA4hZxqeRoS5BMX/YOcDiGdNbSuqv+iG5GSckJ99YUI67Cw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.4.5':
     resolution: {integrity: sha512-6eOhh18VD8x5+SJrs/K6XiDw+FYffzDMsI3Sz78mQW5xvHYzN3HJxIw7oG7UYXqF5I2yORmqvdxV1aAnv8Fc4g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.4.6':
+    resolution: {integrity: sha512-3p5u9q/Q9MMVe+5XFJ/WiFrzNrrxUjJFR19kB1k/KMcf8ox982xWjnfJuBkET/k7Hn0EZL7L06ym447uIfAVAg==}
     cpu: [x64]
     os: [darwin]
 
@@ -564,8 +579,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-gnu@1.4.6':
+    resolution: {integrity: sha512-ZrrCn5b037ImZfZ3MShJrRw4d5M3Tq2rFJupr+SGMg7GTl2T6xEmo3ER/evHlT6e0ETi6tRWPxC9A1125jbSQA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-arm64-musl@1.4.5':
     resolution: {integrity: sha512-E4dUEDpAsQ5jTvt8AXs0VY3vxTzSf07CM5zi797VaFzZzbcZqAoBmlAxYTSyl7/BgAxHSg8AYJS5c8l03vXM4w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@1.4.6':
+    resolution: {integrity: sha512-0a30oR6ZmZrqmsOHQYrbZPCxAgnqAiqlbFozdhHs+Yu2bS7SDiLpdjMg0PHwLZT2+siiMWsLodFZlXRJE54oAQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -574,8 +599,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-gnu@1.4.6':
+    resolution: {integrity: sha512-u6pq1aq7bX+NABVDDTOzH64KMj1KJn8fUWO+FaX7Kr7PBjhmxNRs4OaWZjbXEY6COhMYEJZ04h4DhY+lRzcKjA==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-musl@1.4.5':
     resolution: {integrity: sha512-bOZmkCZamOz/+D3AA3uHII3rLIx4WtPk+KbDe3nfIVHhgxUK1nmv0vHtKzDA5iplucJ4ha/Rx9TEFyRwnBJH0A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@1.4.6':
+    resolution: {integrity: sha512-rjP/1dWKB828kzd4/QpDYNVasUAKDj0OeRJGh5L/RluSH3pEqhxm5FwvndpmFDv6m3iPekZ4IO26UrpGJmE9fw==}
     cpu: [x64]
     os: [linux]
 
@@ -583,8 +618,17 @@ packages:
     resolution: {integrity: sha512-LRyln0jg2FblwFQg+0lPVc/bvDeo3A3EVWQtsTtOwjb4cjAG/Zqo5Q0VobaJTKgBOF9eAHTo9IL92SSj433+Eg==}
     cpu: [wasm32]
 
+  '@rspack/binding-wasm32-wasi@1.4.6':
+    resolution: {integrity: sha512-5M0g7TaWgCFQJr4NKYW2bTLbQJuAQIgZL7WmiDwotgscBJDQWJVBayFEsnM6PYX1Inmu6RNhQ44BKIYwwoSyYw==}
+    cpu: [wasm32]
+
   '@rspack/binding-win32-arm64-msvc@1.4.5':
     resolution: {integrity: sha512-JWc15Mof/aC41UQSZLwa6oEsPYaYCApW0152Abhnt27qir2pfqYcT5qWt26OJvFDJoe+KzpIG1H91yJviChYYw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@1.4.6':
+    resolution: {integrity: sha512-thPCdbh4O+uEAJ8AvXBWZIOW0ZopJAN3CX2zlprso8Cnhi4wDseTtrIxFQh7cTo6pR3xSZAIv/zHd+MMF8TImA==}
     cpu: [arm64]
     os: [win32]
 
@@ -593,16 +637,38 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@1.4.6':
+    resolution: {integrity: sha512-KQmm6c/ZfJKQ/TpzbY6J0pDvUB9kwTXzp+xl2FhGq2RXid8uyDS8ZqbeJA6LDxgttsmp4PRVJjMdLVYjZenfLw==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@1.4.5':
     resolution: {integrity: sha512-elzpVGJW0W9DTkfJ7JyvMyi2Rbot5Q6rVBBKSh0lRWhZE/LnDJ/1WkS/9yER8XPGjO7umP1hD72ML1SoBddXmA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@1.4.6':
+    resolution: {integrity: sha512-WRRhCsJ+xcOmvzo/r/b2UTejPLnDEbaD/te1yQwHe97sUaFGr3u1Njk6lVYRTV6mEvUopEChb8yAq/S4dvaGLg==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@1.4.5':
     resolution: {integrity: sha512-hO7DrZMMOyzwK7EEYfHMJmWhsNjeYLr39pEnXOWeuCCcwus6e/QNSSf2m/2mSFf0JeINwQqHkA1JvJEZ5JSj6g==}
 
+  '@rspack/binding@1.4.6':
+    resolution: {integrity: sha512-rRc6sbKWxhomxxJeqi4QS3S/2T6pKf4JwC/VHXs7KXw7lHXHa3yxPynmn3xHstL0H6VLaM5xQj87Wh7lQYRAPg==}
+
   '@rspack/core@1.4.5':
     resolution: {integrity: sha512-4OlxGQ4yPbAOYbVStMotaYrydm8r5VbLByrmQ34LNBYIDSmwaBmHQVMYGIesuGW681pr139XwInKvsoAoW6VTA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@1.4.6':
+    resolution: {integrity: sha512-/OpJLv7dPEE7x/qCXGecRm9suNxz5w0Dheq2sh0TjTCUHodtMET3T+FlRWznBAlZeNuHLECDp0DWhchgS8BWuA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -623,8 +689,8 @@ packages:
       webpack-hot-middleware:
         optional: true
 
-  '@rspress/core@2.0.0-beta.18':
-    resolution: {integrity: sha512-crLnWGmU8E8rZLsL7zGrbBzQNXbwhI8ZLQ+xUzLJSfnRl1sqL2bhhm2MJu4Dm8qgiwUzGbPmchp+wr41jx8pDw==}
+  '@rspress/core@2.0.0-beta.21':
+    resolution: {integrity: sha512-dBAvUi2CWw0cyEKE2vafHylzEuZxKcQ+nysLr/cIjrau6s7p3ghajEXYT+nLrpzv2bBeUDURmRYKSuPch+bWzA==}
     engines: {node: '>=18.0.0'}
 
   '@rspress/mdx-rs-darwin-arm64@0.6.6':
@@ -679,25 +745,15 @@ packages:
     resolution: {integrity: sha512-NpNhTKBIlV3O6ADhoZkgHvBFvXMW2TYlIWmIT1ysJESUBqDpaN9H3Teve5fugjU2pQ2ORBZO6SQGKliMw/8m/Q==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-last-updated@2.0.0-beta.18':
-    resolution: {integrity: sha512-0uUaLSrHNlu50kQv6wYlBc/KOEEZamY9btbmlk2aFRRXGbPTYAmTOVpab0CtXl3xCPjFcshdNKgwDteggAja+Q==}
+  '@rspress/runtime@2.0.0-beta.21':
+    resolution: {integrity: sha512-uYCqzaHTwglSdgoKh1jDAjj73bIup7END/pVDTh+ILrhwkHyEbTXpuRn4km3QwqnPjEN80hVjpuzSzbWx80DjA==}
     engines: {node: '>=18.0.0'}
 
-  '@rspress/plugin-medium-zoom@2.0.0-beta.18':
-    resolution: {integrity: sha512-+WlMYxQtidOfWc5JJ8mGsHIjy5AY135eC6tSnY/ud8RZxxvHPgy8gWBpsd6mtlQcaju2yckTPW8W/P/hiZ3kpQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@rspress/runtime': ^2.0.0-beta.18
+  '@rspress/shared@2.0.0-beta.21':
+    resolution: {integrity: sha512-Q/yjGH/afdkJY0AJ7FwxnvilD21kFmLhcCsMDzMEnW0U9LGnD+T+J3JoBhHvetTSHfrqg9rKl9YnJ5oreq89vQ==}
 
-  '@rspress/runtime@2.0.0-beta.18':
-    resolution: {integrity: sha512-H6WZNxiYPysxfHJCjB/G2IDvAMotXhfaQZKaMMwdq8LvVczFIYeY4DgwUSsDyHCaZTlwZ6NINF/FK7tDcU99Qw==}
-    engines: {node: '>=18.0.0'}
-
-  '@rspress/shared@2.0.0-beta.18':
-    resolution: {integrity: sha512-BW4f2M7vx0rm3+WMUKVvNW/ZqAwlBK01Vw8LJztj/laAf5yiLI2fCPbfSrSBBl2vzAxC/ct7GYjnQv8NFThlUg==}
-
-  '@rspress/theme-default@2.0.0-beta.18':
-    resolution: {integrity: sha512-Yxje26/RCl/8etaFNhKzoWcwPw7Kmu9p9thn9jaROAkXCqpfrKoUva1SQJyxSdrpRSsuW1HIGb8VO5L2BLQCNQ==}
+  '@rspress/theme-default@2.0.0-beta.21':
+    resolution: {integrity: sha512-G+yJiAZW0oiAB7FyMFWrEI5B/Lg3z2IdxegbGo3a9q2tYo24bd35YuuXOQOIPuE/0+hWxCtB1vxDYH6WyZwMIQ==}
     engines: {node: '>=18.0.0'}
 
   '@rushstack/node-core-library@5.13.1':
@@ -884,8 +940,8 @@ packages:
   '@ungap/structured-clone@1.2.1':
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
 
-  '@unhead/react@2.0.11':
-    resolution: {integrity: sha512-Bs5jBelfqgIghfE7FbiXEzRT9VwScPLd4K3LCGyZogScAsFsXjKcwt97GzEcVgn2W7QeJE9Y2F0l1hQFvpLmzQ==}
+  '@unhead/react@2.0.12':
+    resolution: {integrity: sha512-2qRwLtPVUDWHIP2n3S3gL0jT+Wcalb0huCgf/GFXYhV8ZWqm+5+ZTLVlPN7O5q3aVhIGO2gZHsppXNVq+L3fuQ==}
     peerDependencies:
       react: '>=18'
 
@@ -1211,6 +1267,10 @@ packages:
 
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.18.2:
+    resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -2088,8 +2148,8 @@ packages:
   rspack-plugin-virtual-module@1.0.1:
     resolution: {integrity: sha512-NQJ3fXa1v0WayvfHMWbyqLUA3JIqgCkhIcIOnZscuisinxorQyIAo+bqcU5pCusMKSyPqVIWO3caQyl0s9VDAg==}
 
-  rspress@2.0.0-beta.18:
-    resolution: {integrity: sha512-P3qEqzfDH860ZbFrxTAf836QDeUbTy2NSZOeqYN/WPwXom9Pojf2PL+LTrqIvcl/6sbLG+/TnCAbxE9dQYeqmg==}
+  rspress@2.0.0-beta.21:
+    resolution: {integrity: sha512-dgporOEoGogsxI4y/xAgnmENL8S/YIUi8c8JkJqmyNQET+eyZ9jF83WopP7YaxyDGY1j43cXiFf0bhUMVB8i8w==}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -2403,8 +2463,8 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
-  unhead@2.0.11:
-    resolution: {integrity: sha512-wob9IFYcCH6Tr+84P6/m2EDhdPgq/Fb8AlLEes/2eE4empMHfZk/qFhA7cCmIiXRCPqUFt/pN+nIJVs5nEp9Ng==}
+  unhead@2.0.12:
+    resolution: {integrity: sha512-5oo0lwz81XDXCmrHGzgmbaNOxM8R9MZ3FkEs2ROHeW8e16xsrv7qXykENlISrcxr3RLPHQEsD1b6js9P2Oj/Ow==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2856,8 +2916,8 @@ snapshots:
 
   '@jridgewell/source-map@0.3.6':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
     optional: true
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
@@ -3086,6 +3146,14 @@ snapshots:
       core-js: 3.44.0
       jiti: 2.4.2
 
+  '@rsbuild/core@1.4.6':
+    dependencies:
+      '@rspack/core': 1.4.6(@swc/helpers@0.5.17)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.17
+      core-js: 3.44.0
+      jiti: 2.4.2
+
   '@rsbuild/plugin-image-compress@1.2.0(@rsbuild/core@1.4.5)':
     dependencies:
       '@napi-rs/image': 1.11.0
@@ -3096,6 +3164,14 @@ snapshots:
   '@rsbuild/plugin-react@1.3.4(@rsbuild/core@1.4.5)':
     dependencies:
       '@rsbuild/core': 1.4.5
+      '@rspack/plugin-react-refresh': 1.4.3(react-refresh@0.17.0)
+      react-refresh: 0.17.0
+    transitivePeerDependencies:
+      - webpack-hot-middleware
+
+  '@rsbuild/plugin-react@1.3.4(@rsbuild/core@1.4.6)':
+    dependencies:
+      '@rsbuild/core': 1.4.6
       '@rspack/plugin-react-refresh': 1.4.3(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
@@ -3136,19 +3212,37 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.4.5':
     optional: true
 
+  '@rspack/binding-darwin-arm64@1.4.6':
+    optional: true
+
   '@rspack/binding-darwin-x64@1.4.5':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.4.6':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.4.5':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@1.4.6':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@1.4.5':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.4.6':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.4.5':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@1.4.6':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@1.4.5':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.4.6':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.4.5':
@@ -3156,13 +3250,27 @@ snapshots:
       '@napi-rs/wasm-runtime': 0.2.11
     optional: true
 
+  '@rspack/binding-wasm32-wasi@1.4.6':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.11
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@1.4.5':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@1.4.6':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.4.5':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@1.4.6':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.4.5':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.4.6':
     optional: true
 
   '@rspack/binding@1.4.5':
@@ -3178,10 +3286,31 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.4.5
       '@rspack/binding-win32-x64-msvc': 1.4.5
 
+  '@rspack/binding@1.4.6':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.4.6
+      '@rspack/binding-darwin-x64': 1.4.6
+      '@rspack/binding-linux-arm64-gnu': 1.4.6
+      '@rspack/binding-linux-arm64-musl': 1.4.6
+      '@rspack/binding-linux-x64-gnu': 1.4.6
+      '@rspack/binding-linux-x64-musl': 1.4.6
+      '@rspack/binding-wasm32-wasi': 1.4.6
+      '@rspack/binding-win32-arm64-msvc': 1.4.6
+      '@rspack/binding-win32-ia32-msvc': 1.4.6
+      '@rspack/binding-win32-x64-msvc': 1.4.6
+
   '@rspack/core@1.4.5(@swc/helpers@0.5.17)':
     dependencies:
       '@module-federation/runtime-tools': 0.15.0
       '@rspack/binding': 1.4.5
+      '@rspack/lite-tapable': 1.0.1
+    optionalDependencies:
+      '@swc/helpers': 0.5.17
+
+  '@rspack/core@1.4.6(@swc/helpers@0.5.17)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.15.0
+      '@rspack/binding': 1.4.6
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:
       '@swc/helpers': 0.5.17
@@ -3194,29 +3323,28 @@ snapshots:
       html-entities: 2.6.0
       react-refresh: 0.17.0
 
-  '@rspress/core@2.0.0-beta.18(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.97.1)':
+  '@rspress/core@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.97.1)':
     dependencies:
       '@mdx-js/loader': 3.1.0(acorn@8.14.0)(webpack@5.97.1)
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       '@mdx-js/react': 3.1.0(@types/react@19.1.8)(react@19.1.0)
-      '@rsbuild/core': 1.4.5
-      '@rsbuild/plugin-react': 1.3.4(@rsbuild/core@1.4.5)
+      '@rsbuild/core': 1.4.6
+      '@rsbuild/plugin-react': 1.3.4(@rsbuild/core@1.4.6)
       '@rspress/mdx-rs': 0.6.6
-      '@rspress/plugin-last-updated': 2.0.0-beta.18
-      '@rspress/plugin-medium-zoom': 2.0.0-beta.18(@rspress/runtime@2.0.0-beta.18)
-      '@rspress/runtime': 2.0.0-beta.18
-      '@rspress/shared': 2.0.0-beta.18
-      '@rspress/theme-default': 2.0.0-beta.18
+      '@rspress/runtime': 2.0.0-beta.21
+      '@rspress/shared': 2.0.0-beta.21
+      '@rspress/theme-default': 2.0.0-beta.21
       '@shikijs/rehype': 3.7.0
       '@types/unist': 3.0.3
-      '@unhead/react': 2.0.11(react@19.1.0)
-      enhanced-resolve: 5.18.1
+      '@unhead/react': 2.0.12(react@19.1.0)
+      enhanced-resolve: 5.18.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-heading-rank: 3.0.0
       html-to-text: 9.0.5
       lodash-es: 4.17.21
       mdast-util-mdxjs-esm: 2.0.1
+      medium-zoom: 1.1.0
       picocolors: 1.1.1
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -3274,37 +3402,28 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.6
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.6
 
-  '@rspress/plugin-last-updated@2.0.0-beta.18':
+  '@rspress/runtime@2.0.0-beta.21':
     dependencies:
-      '@rspress/shared': 2.0.0-beta.18
-
-  '@rspress/plugin-medium-zoom@2.0.0-beta.18(@rspress/runtime@2.0.0-beta.18)':
-    dependencies:
-      '@rspress/runtime': 2.0.0-beta.18
-      medium-zoom: 1.1.0
-
-  '@rspress/runtime@2.0.0-beta.18':
-    dependencies:
-      '@rspress/shared': 2.0.0-beta.18
-      '@unhead/react': 2.0.11(react@19.1.0)
+      '@rspress/shared': 2.0.0-beta.21
+      '@unhead/react': 2.0.12(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  '@rspress/shared@2.0.0-beta.18':
+  '@rspress/shared@2.0.0-beta.21':
     dependencies:
-      '@rsbuild/core': 1.4.5
+      '@rsbuild/core': 1.4.6
       '@shikijs/rehype': 3.7.0
       gray-matter: 4.0.3
       lodash-es: 4.17.21
       unified: 11.0.5
 
-  '@rspress/theme-default@2.0.0-beta.18':
+  '@rspress/theme-default@2.0.0-beta.21':
     dependencies:
       '@mdx-js/react': 2.3.0(react@19.1.0)
-      '@rspress/runtime': 2.0.0-beta.18
-      '@rspress/shared': 2.0.0-beta.18
-      '@unhead/react': 2.0.11(react@19.1.0)
+      '@rspress/runtime': 2.0.0-beta.21
+      '@rspress/shared': 2.0.0-beta.21
+      '@unhead/react': 2.0.12(react@19.1.0)
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.7.43
@@ -3544,10 +3663,10 @@ snapshots:
 
   '@ungap/structured-clone@1.2.1': {}
 
-  '@unhead/react@2.0.11(react@19.1.0)':
+  '@unhead/react@2.0.12(react@19.1.0)':
     dependencies:
       react: 19.1.0
-      unhead: 2.0.11
+      unhead: 2.0.12
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -3892,6 +4011,12 @@ snapshots:
   emojis-list@3.0.0: {}
 
   enhanced-resolve@5.18.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.1
+    optional: true
+
+  enhanced-resolve@5.18.2:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
@@ -5157,11 +5282,11 @@ snapshots:
     dependencies:
       fs-extra: 11.3.0
 
-  rspress@2.0.0-beta.18(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.97.1):
+  rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.97.1):
     dependencies:
-      '@rsbuild/core': 1.4.5
-      '@rspress/core': 2.0.0-beta.18(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.97.1)
-      '@rspress/shared': 2.0.0-beta.18
+      '@rsbuild/core': 1.4.6
+      '@rspress/core': 2.0.0-beta.21(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.97.1)
+      '@rspress/shared': 2.0.0-beta.21
       cac: 6.7.14
       chokidar: 3.6.0
       picocolors: 1.1.1
@@ -5394,7 +5519,7 @@ snapshots:
 
   terser-webpack-plugin@5.3.10(webpack@5.97.1):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.29
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
@@ -5443,7 +5568,7 @@ snapshots:
 
   undici-types@6.19.8: {}
 
-  unhead@2.0.11:
+  unhead@2.0.12:
     dependencies:
       hookable: 5.5.3
 


### PR DESCRIPTION
### Summary

`rspress@2.0.0-beta.21` made `@rspress/shared` etc. private and all external imports should now use `rspress/core` or `rspress/runtime` imports which this PR aims to do.

this bumps the minimum requirement of `rspress` version to `^2.0.0-beta.21`

### Test plan

- [x] - tester works
