### PR TITLE
fix: button background edge case

### DIFF
--- a/packages/theme/src/theme/components/button/index.module.scss
+++ b/packages/theme/src/theme/components/button/index.module.scss
@@ -31,7 +31,8 @@
 .button.alt,
 :global(.dark) .button.brand {
   background: linear-gradient(to right, var(--rp-c-brand) 50%, #ffffff 50%)
-    right bottom / 200% 100%;
+    // add 1px to avoid subpixel problems (lagging 1px violet background) in odd-width buttons
+    right bottom / calc(200% + 1px) 100%;
   color: #201f24;
 }
 
@@ -39,7 +40,8 @@
 .button.brand,
 :global(.dark) .button.alt {
   background: linear-gradient(to right, var(--rp-c-brand) 50%, #201f24 50%)
-    right bottom / 200% 100%;
+    // add 1px to avoid subpixel problems (lagging 1px violet background) in odd-width buttons
+    right bottom / calc(200% + 1px) 100%;
   color: #ffffff;
 }
 


### PR DESCRIPTION
### Summary

This PR fixes an edge case with (likely) subpixel rendering rounding issue in specific layouts, likely due to odd widths of the `Button` component. In such cases, the component in non-focused state would be displayed with the background purple color remaining in the view box of the button by 1px from the left:

<img width="297" height="148" alt="Screenshot 2025-07-18 at 13 41 06" src="https://github.com/user-attachments/assets/e74aeca2-1736-4884-9adf-ea32e585ccee" />

<img height="200" alt="Screenshot 2025-07-18 at 13 41 13" src="https://github.com/user-attachments/assets/50b3ae7f-a85c-4080-b80b-2dc0610efa0f" />

The workaround is to extend the left rectangle's width by an extra margin of 1px.

Thanks to @thymikee for suggesting the idea for this workaround!

### Test plan

Test the RN Legal docs, where the "CLI" button used to suffer from this issue.