### PR TITLE
feat: display footer message from rspress theme config

### DIFF
--- a/packages/tester/rspress.config.ts
+++ b/packages/tester/rspress.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
     },
   },
   themeConfig: {
+    footer: {
+      message: 'Copyright © 2025 Callstack',
+    },
     editLink: {
       docRepoBaseUrl: 'https://github.com/callstack/rspress-theme',
       text: 'Edit this page on GitHub',

--- a/packages/theme/src/theme/components/home-footer/index.module.scss
+++ b/packages/theme/src/theme/components/home-footer/index.module.scss
@@ -18,6 +18,15 @@
   position: relative;
 }
 
+.message {
+  color: var(--rp-c-text-3);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.5;
+  text-align: center;
+  margin: 0 8px;
+}
+
 @media (max-width: 960px) {
   .container {
     margin: 0 auto 64px auto;

--- a/packages/theme/src/theme/components/home-footer/index.tsx
+++ b/packages/theme/src/theme/components/home-footer/index.tsx
@@ -36,6 +36,9 @@ function HomeFooter(props: HomeFooterProps) {
             <CKLogoLight className="dark:rp-hidden" />
           </div>
         </LinkComponent>
+        <span className={styles.message}>
+          {siteData.themeConfig.footer?.message}
+        </span>
         <SocialLinksComponent socialLinks={siteData.themeConfig.socialLinks} />
       </div>
     </div>


### PR DESCRIPTION
### Summary

This PR adds an ability to add custom footer message through buitlin Rspress `themeConfig.footer.message` prop

### Test plan

n/a
