### PR TITLE
feat: configure content directly from plugin

### DIFF
--- a/packages/tester/rspress.config.ts
+++ b/packages/tester/rspress.config.ts
@@ -44,6 +44,14 @@ export default defineConfig({
   },
   plugins: [
     pluginCallstackTheme({
+      content: {
+        homeBannerButtonText: 'Home Banner Button Text',
+        homeBannerDescription: 'Home Banner Description',
+        homeBannerHeadline: 'Home Banner Headline',
+        outlineCTAButtonText: 'Outline CTA Button Text',
+        outlineCTADescription: 'Outline CTA Description',
+        outlineCTAHeadline: 'Outline CTA Headline',
+      },
       links: {
         homeBanner: 'https://callstack.com?source=banner',
         homeFooter: 'https://callstack.com?source=footer',

--- a/packages/theme/src/plugin/const.ts
+++ b/packages/theme/src/plugin/const.ts
@@ -1,10 +1,23 @@
+export const OUTLINE_TITLE = 'Contents';
+
+export const SEARCH_NO_RESULTS_TEXT =
+  'No results found, try something different than';
+
+export const SEARCH_SUGGESTED_QUERY_TEXT = '';
+
+export const OVERVIEW_FILTER_NAME_TEXT = '';
+
 export const OUTLINE_CTA_BUTTON_TEXT = "Let's talk";
 export const OUTLINE_CTA_DESCRIPTION =
   'We help React Native teams enhance speed, responsiveness, and efficiency.';
 export const OUTLINE_CTA_HEADLINE = "Need to boost your app's performance?";
+export const OUTLINE_CTA_LINK = 'https://callstack.com';
 
 export const HOME_BANNER_HEADLINE =
   'Need React or React Native\nexpertise you can count on?';
 export const HOME_BANNER_DESCRIPTION =
   "We've spent years building full-stack, cross-platform apps and solving tough technical challenges.";
 export const HOME_BANNER_BUTTON_TEXT = "Let's talk";
+export const HOME_BANNER_LINK = 'https://callstack.com';
+
+export const HOME_FOOTER_LINK = 'https://callstack.com';

--- a/packages/theme/src/plugin/index.ts
+++ b/packages/theme/src/plugin/index.ts
@@ -3,11 +3,20 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { RspressPlugin, UserConfig } from '@rspress/core';
+import * as consts from './const';
 
 type BuilderConfig = NonNullable<UserConfig['builderConfig']>;
 type AliasEntry = string | (false | string)[] | false | undefined;
 
 interface PluginCallstackThemeOptions {
+  content?: {
+    homeBannerButtonText?: string;
+    homeBannerDescription?: string;
+    homeBannerHeadline?: string;
+    outlineCTAButtonText?: string;
+    outlineCTADescription?: string;
+    outlineCTAHeadline?: string;
+  };
   links?: {
     homeBanner?: string;
     homeFooter?: string;
@@ -94,7 +103,25 @@ function getBuilderConfig(options: PluginCallstackThemeOptions): BuilderConfig {
     source: {
       define: {
         HOME_BANNER_LINK: JSON.stringify(options.links?.homeBanner),
+        HOME_BANNER_BUTTON_TEXT: JSON.stringify(
+          options.content?.homeBannerButtonText
+        ),
+        HOME_BANNER_DESCRIPTION: JSON.stringify(
+          options.content?.homeBannerDescription
+        ),
+        HOME_BANNER_HEADLINE: JSON.stringify(
+          options.content?.homeBannerHeadline
+        ),
         HOME_FOOTER_LINK: JSON.stringify(options.links?.homeFooter),
+        OUTLINE_CTA_BUTTON_TEXT: JSON.stringify(
+          options.content?.outlineCTAButtonText
+        ),
+        OUTLINE_CTA_DESCRIPTION: JSON.stringify(
+          options.content?.outlineCTADescription
+        ),
+        OUTLINE_CTA_HEADLINE: JSON.stringify(
+          options.content?.outlineCTAHeadline
+        ),
         OUTLINE_CTA_LINK: JSON.stringify(options.links?.outlineCTA),
       },
     },
@@ -121,22 +148,21 @@ function getBuilderConfig(options: PluginCallstackThemeOptions): BuilderConfig {
 
 function addThemeOverrides(themeConfig: UserConfig['themeConfig'] = {}) {
   if (!themeConfig.overview) {
-    themeConfig.overview = { filterNameText: '' };
+    themeConfig.overview = { filterNameText: consts.OVERVIEW_FILTER_NAME_TEXT };
   } else if (!themeConfig.overview.filterNameText) {
-    themeConfig.overview.filterNameText = '';
+    themeConfig.overview.filterNameText = consts.OVERVIEW_FILTER_NAME_TEXT;
   }
 
   if (!themeConfig.outlineTitle) {
-    themeConfig.outlineTitle = 'Contents';
+    themeConfig.outlineTitle = consts.OUTLINE_TITLE;
   }
 
   if (!themeConfig.searchNoResultsText) {
-    themeConfig.searchNoResultsText =
-      'No results found, try something different than';
+    themeConfig.searchNoResultsText = consts.SEARCH_NO_RESULTS_TEXT;
   }
 
   if (!themeConfig.searchSuggestedQueryText) {
-    themeConfig.searchSuggestedQueryText = '';
+    themeConfig.searchSuggestedQueryText = consts.SEARCH_SUGGESTED_QUERY_TEXT;
   }
 
   return themeConfig;
@@ -144,10 +170,26 @@ function addThemeOverrides(themeConfig: UserConfig['themeConfig'] = {}) {
 
 function normalizeOptions(options: PluginCallstackThemeOptions) {
   return {
+    content: {
+      homeBannerButtonText:
+        options.content?.homeBannerButtonText ?? consts.HOME_BANNER_BUTTON_TEXT,
+      homeBannerDescription:
+        options.content?.homeBannerDescription ??
+        consts.HOME_BANNER_DESCRIPTION,
+      homeBannerHeadline:
+        options.content?.homeBannerHeadline ?? consts.HOME_BANNER_HEADLINE,
+      outlineCTAButtonText:
+        options.content?.outlineCTAButtonText ?? consts.OUTLINE_CTA_BUTTON_TEXT,
+      outlineCTADescription:
+        options.content?.outlineCTADescription ??
+        consts.OUTLINE_CTA_DESCRIPTION,
+      outlineCTAHeadline:
+        options.content?.outlineCTAHeadline ?? consts.OUTLINE_CTA_HEADLINE,
+    },
     links: {
-      homeBanner: options.links?.homeBanner ?? 'https://callstack.com',
-      homeFooter: options.links?.homeFooter ?? 'https://callstack.com',
-      outlineCTA: options.links?.outlineCTA ?? 'https://callstack.com',
+      homeBanner: options.links?.homeBanner ?? consts.HOME_BANNER_LINK,
+      homeFooter: options.links?.homeFooter ?? consts.HOME_FOOTER_LINK,
+      outlineCTA: options.links?.outlineCTA ?? consts.OUTLINE_CTA_LINK,
     },
   };
 }

--- a/packages/theme/src/theme/components/home-banner/index.tsx
+++ b/packages/theme/src/theme/components/home-banner/index.tsx
@@ -1,13 +1,11 @@
 import abstractAtom from '../../assets/abstract-atom.avif';
-import {
-  HOME_BANNER_BUTTON_TEXT,
-  HOME_BANNER_DESCRIPTION,
-  HOME_BANNER_HEADLINE,
-} from '../../const';
 import { Button } from '../button';
 import styles from './index.module.scss';
 
 declare const HOME_BANNER_LINK: string;
+declare const HOME_BANNER_BUTTON_TEXT: string;
+declare const HOME_BANNER_DESCRIPTION: string;
+declare const HOME_BANNER_HEADLINE: string;
 
 interface HomeBannerProps {
   buttonText?: string;

--- a/packages/theme/src/theme/components/outline-cta/index.tsx
+++ b/packages/theme/src/theme/components/outline-cta/index.tsx
@@ -1,12 +1,10 @@
-import {
-  OUTLINE_CTA_BUTTON_TEXT,
-  OUTLINE_CTA_DESCRIPTION,
-  OUTLINE_CTA_HEADLINE,
-} from '../../const';
 import { Button } from '../button';
 import styles from './index.module.scss';
 
 declare const OUTLINE_CTA_LINK: string;
+declare const OUTLINE_CTA_BUTTON_TEXT: string;
+declare const OUTLINE_CTA_DESCRIPTION: string;
+declare const OUTLINE_CTA_HEADLINE: string;
 
 interface OutlineCTAProps {
   buttonText?: string;


### PR DESCRIPTION
### Summary

- [x] - adds an option to configure copy for components from the plugin directly

### Test plan

- [x] - tester works
