### PR TITLE
fix: coloring of aside contents

### DIFF
--- a/packages/tester/docs/test/extra.mdx
+++ b/packages/tester/docs/test/extra.mdx
@@ -86,18 +86,18 @@ module.exports = {
 :::danger Platform-Specific Output
 By default, extracted asset files are copied to `assets/` directory for iOS and `drawable-*` directories (e.g. `drawable-mdpi`, `drawable-hdpi`, etc.) for Android which matches Metro's asset handling behavior.
 
-1. [Inlining assets as base64 strings](/docs/guides/inline-assets)
-1. [Converting to remote assets](/docs/guides/remote-assets)
-1.  [Adding SVG support](/docs/guides/svg)
+1. [Inlining assets as base64 strings](/test/guide)
+1. [Converting to remote assets](/test/guide)
+1.  [Adding SVG support](/test/guide)
 
 :::
 
 :::tip Guides related to AssetsLoader
 Looking to do more with your assets? Check out the guides on:
 
-- [Inlining assets as base64 strings](/docs/guides/inline-assets)
-- [Converting to remote assets](/docs/guides/remote-assets)
-- [Adding SVG support](/docs/guides/svg)
+- [Inlining assets as base64 strings](/test/guide)
+- [Converting to remote assets](/test/guide)
+- [Adding SVG support](/test/guide)
 
 :::
 

--- a/packages/theme/src/styles/styles.css
+++ b/packages/theme/src/styles/styles.css
@@ -437,8 +437,15 @@ div[class^="collapseContainer_"]:hover {
   color: var(--rp-c-text-1) !important;
 }
 
-.aside-link:hover {
+/* use specific selector to avoid being stripped when compiling */
+li > a.aside-link:hover {
   background-color: var(--ck-foreground-primary) !important;
+}
+
+/* replace margin-left with padding-left for proper hover higlight */
+li > a.aside-link[style*="margin-left: 12px"] {
+  margin-left: 0 !important;
+  padding-left: 12px;
 }
 
 /* Content - active link */


### PR DESCRIPTION
### Summary

- [x] - fix color of aside contents in production bundles
- [x] - adjust link highlight size when hovering in aside bar

<img width="632" height="840" alt="CleanShot 2025-09-15 at 11 20 42@2x" src="https://github.com/user-attachments/assets/f3f79a62-75e8-4285-8f99-1b81c250d0a9" />


### Test plan

n/a
