### PR TITLE
fix: use shorter footer message in preset

### DIFF
--- a/packages/preset/src/preset.ts
+++ b/packages/preset/src/preset.ts
@@ -87,7 +87,7 @@ const createPreset = (config: PresetConfig): UserConfig => {
       enableContentAnimation: true,
       enableScrollToTop: false,
       footer: {
-        message: `Copyright © ${new Date().getFullYear()} Callstack Open Source`,
+        message: `Copyright © ${new Date().getFullYear()} Callstack`,
       },
       editLink: {
         docRepoBaseUrl: docs.editUrl,


### PR DESCRIPTION
### Summary

- [x] - use shorter name in footer to avoid multiline 

### Test plan

n/a
