### PR TITLE
fix: aside contents positioning without any contents

### DIFF
--- a/packages/theme/src/styles/styles.css
+++ b/packages/theme/src/styles/styles.css
@@ -422,10 +422,13 @@ div[class^="collapseContainer_"]:hover {
   display: none !important;
 }
 
+div[class^="aside-container_"] {
+  padding-top: 0 !important;
+}
+
 /* Table of Contents */
 #aside-container {
   border-left: 1px solid var(--rp-c-divider-light) !important;
-  margin: -64px 0 0 0 !important;
   padding: 16px 0 16px 0 !important;
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

- [x] - fixes an issue where the aside container would leave a big gap on top when no contents are present on a given page

Before:
<img width="658" height="742" alt="CleanShot 2025-09-15 at 12 22 49@2x" src="https://github.com/user-attachments/assets/0a81f384-f6ef-45e4-93d3-b4db87152172" />

After:
<img width="630" height="732" alt="CleanShot 2025-09-15 at 12 24 25@2x" src="https://github.com/user-attachments/assets/17d45fab-88e7-4fbf-9703-f585673f32cc" />

### Test plan

- [x] - tester works
