### PR TITLE
fix: styling regressions

### DIFF
--- a/.changeset/old-apples-knock.md
+++ b/.changeset/old-apples-knock.md
@@ -1,0 +1,6 @@
+---
+'@callstack/rspress-theme': patch
+'@callstack/rspress-preset': patch
+---
+
+fix: styling regressions

--- a/packages/theme/src/styles/components.css
+++ b/packages/theme/src/styles/components.css
@@ -22,6 +22,10 @@ a.rp-edit-link::before {
   margin-left: -1em !important;
 }
 
+.rp-header-anchor:hover {
+  border-bottom: none !important;
+}
+
 /* doc page header */
 .rp-doc.rspress-doc > h1.rp-toc-include {
   margin-bottom: 1.5rem !important;
@@ -52,6 +56,10 @@ a.rp-edit-link::before {
   color: var(--rp-c-text-2) !important;
 }
 
+.rp-outline__action-row.rp-edit-link {
+  display: none !important;
+}
+
 .rp-doc p > code {
   padding: 0.1em 0.2em;
   font-size: 1em !important;
@@ -59,7 +67,7 @@ a.rp-edit-link::before {
 }
 
 .rp-code-button-group {
-  top: 8px !important;
+  top: 14px !important;
   right: 8px !important;
 }
 

--- a/packages/theme/src/styles/links.css
+++ b/packages/theme/src/styles/links.css
@@ -19,7 +19,7 @@ p > .rp-link {
   border-bottom: 1px solid var(--rp-c-text-1);
 }
 
-/* remove arrow from links */
-.rp-link:after {
+/* remove arrow from links except external ones */
+.rp-link:not(.rp-sidebar-item--active):not([target="_blank"]):after {
   content: none !important;
 }

--- a/packages/theme/src/styles/nav.css
+++ b/packages/theme/src/styles/nav.css
@@ -24,6 +24,11 @@
   margin-top: 0 !important;
 }
 
+.rp-sidebar-item:not(:last-child),
+.rp-sidebar-item--active:not(:last-child) {
+  margin-bottom: 8px !important;
+}
+
 .rp-sidebar-item:hover {
   background-color: var(--ck-foreground-primary) !important;
 }
@@ -31,6 +36,18 @@
 .rp-sidebar-item--active {
   color: var(--rp-c-brand) !important;
   font-weight: 400 !important;
+  position: relative !important;
+}
+
+.rp-sidebar-item--active::after {
+  content: "";
+  background-color: var(--rp-c-brand);
+  width: 1px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
 }
 
 /* Section header text */

--- a/packages/theme/src/styles/nav.css
+++ b/packages/theme/src/styles/nav.css
@@ -7,7 +7,7 @@
   /* we want full width sidebar highlights on hover */
   padding-left: 0 !important;
   padding-right: 0 !important;
-  scrollbar-width: thin;
+  scrollbar-width: none;
 }
 
 /* Nav items */

--- a/packages/theme/src/styles/toc.css
+++ b/packages/theme/src/styles/toc.css
@@ -12,6 +12,11 @@ aside.rp-doc-layout__outline > div.rp-outline {
   line-height: 1.5 !important;
   color: var(--rp-c-text-1) !important;
   border-left: none !important;
+  height: auto !important;
+}
+
+.rp-outline__title {
+  padding-left: 12px !important;
 }
 
 /* spacing between toc items */
@@ -20,6 +25,11 @@ aside.rp-doc-layout__outline > div.rp-outline {
   padding-bottom: 4px !important;
   margin-top: 0 !important;
 }
+
+.rp-toc-item__text {
+  font-size: 13px !important;
+}
+
 
 /* hide progress circle */
 svg.rp-progress-circle {
@@ -35,10 +45,16 @@ svg.rp-progress-circle {
 .rp-toc-item {
   margin-left: -20px !important;
   margin-right: -20px !important;
-  padding-left: 20px !important;
-  padding-right: 20px !important;
+  padding-left: 12px !important;
+  padding-right: 12px !important;
 }
 
 .rp-toc-item--active:before {
   left: 0 !important;
+  background-color: var(--rp-c-text-1) !important;
+  width: 1px !important;
+}
+
+.rp-outline__divider {
+  margin-left: 12px !important;
 }

--- a/packages/theme/src/styles/variables.css
+++ b/packages/theme/src/styles/variables.css
@@ -127,6 +127,7 @@
   /* rspress code colors */
   --rp-code-title-bg: rgba(233, 231, 238, 1) !important;
   --rp-code-block-bg: rgba(249, 248, 253, 1) !important;
+  --rp-code-block-border: none !important;
   /* rspress inline code colors */
   --rp-c-text-code: var(--rp-c-text-1) !important;
   --rp-c-text-code-bg: var(--ck-border-secondary) !important;
@@ -174,6 +175,7 @@
   /* rspress code colors */
   --rp-code-title-bg: rgba(54, 53, 57, 1) !important;
   --rp-code-block-bg: rgba(43, 42, 47, 1) !important;
+  --rp-code-block-border: none !important;
   /* rspress inline code colors */
   --rp-c-text-code-bg: var(--ck-border-primary) !important;
 }

--- a/packages/theme/src/theme/components/prev-next-page/index.module.scss
+++ b/packages/theme/src/theme/components/prev-next-page/index.module.scss
@@ -30,23 +30,23 @@
 }
 
 .pagerLink:hover,
-.pagerLink:focus {
+.pagerLink:focus-visible {
   border-color: var(--ck-accent);
   background-position: left bottom;
 }
 
 .pagerLink:hover .title,
-.pagerLink:focus .title {
+.pagerLink:focus-visible .title {
   color: var(--ck-accent);
 }
 
 .pagerLink:hover .iconBox,
-.pagerLink:focus .iconBox {
+.pagerLink:focus-visible .iconBox {
   background-color: var(--ck-accent);
 }
 
 .pagerLink:hover .icon,
-.pagerLink:focus .icon {
+.pagerLink:focus-visible .icon {
   color: #ffffff;
 }
 


### PR DESCRIPTION
Addressed the following styling issues:

> - for codeblocks, previously it was no border, but now it is has border - not sure if intentional
> - there is now a edit button in the sidebar which looks broken (2 icons, no spacing before marketing copy), there is also an edit button at the bottom so another one seems unexpected
> - the right border on active items in the sidebar is gone, not sure if it's intentional. also seems there is no spacing between sidebar items now
> - probably a bug in the theme itself, if i click the "Next page"/"Previous page" buttons at the bottom, it keeps its active styling even on the next page
> - the # link that you get before the heading when you hover it now has an underline when you hover the # - seems unintentional
> - the TOC on the right side don't have proper padding to show heading level like before
> - previously external links had this arrow after them, but now it's gone
> - the padding around the copy and wrap buttons on the codeblocks changed - previously they looked centered for single line codeblocks, but now they don't

### Screenshots before and after the fixes

<img width="953" height="648" alt="image" src="https://github.com/user-attachments/assets/061a972e-eef8-4f83-bb49-df0c21d13940" />

<img width="1159" height="641" alt="image" src="https://github.com/user-attachments/assets/ef3fc70d-a0a7-45f3-b446-ac85f35f8445" />

<img width="708" height="555" alt="image" src="https://github.com/user-attachments/assets/15748e0e-ff8e-4c39-93c5-ca3514ffeb25" />


https://github.com/user-attachments/assets/f722803d-21d4-4f4d-b3ee-c1857715ded3

<img width="662" height="403" alt="image" src="https://github.com/user-attachments/assets/c14bd0f8-3845-48fc-9793-734f70681776" />

<img width="936" height="372" alt="image" src="https://github.com/user-attachments/assets/e60956bb-c342-4492-8ff4-76f495ab1fb6" />

<img width="738" height="354" alt="image" src="https://github.com/user-attachments/assets/66160320-a5b8-4c60-94ec-c665132e839b" />

<img width="793" height="369" alt="image" src="https://github.com/user-attachments/assets/6ccd89f6-7915-4613-b43a-6a8ce0fb66a0" />
