### PR TITLE
fix: hide duplicate mobile sidebar menu icon

### DIFF
--- a/packages/theme/src/styles/nav.css
+++ b/packages/theme/src/styles/nav.css
@@ -204,7 +204,8 @@ button.rp-nav-hamburger > img {
   margin-left: -6px !important;
 }
 
-.rp-sidebar-menu__left > img {
+.rp-sidebar-menu__left > img,
+.rp-sidebar-menu__left > svg {
   display: none !important;
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes a duplicated mobile sidebar menu icon that was reported on Slack.

In newer Rspress versions, the mobile sidebar `Menu` button renders its built-in icon as an inline `svg`. The theme already adds its own menu icon via `::before`, but only hid the old `img` icon shape. As a result, both icons could appear next to each other on mobile.

This updates the CSS rule to hide both `img` and `svg` children inside `.rp-sidebar-menu__left`, leaving only the theme-provided icon visible.

### Test plan

- Open the tester app on a mobile viewport.
- Visit a sidebar page, for example `/nav/section-a/section-a-intro`.
- Verify the sticky `Menu` row shows only one menu icon.
- Tap `Menu` and verify the sidebar still opens correctly.
- Visit `/test/guide` on mobile and verify:
  - `Menu` still opens the sidebar.
  - `Contents` still opens the outline panel.
  - The top mobile nav hamburger still opens the nav menu.
- Switch to desktop width and verify:
  - The regular sidebar is visible.
  - The mobile sticky menu row is collapsed/hidden.
  - The desktop nav still looks unchanged.
- Ran `pnpm lint`.
- Ran `pnpm typecheck`.